### PR TITLE
Update module_download function to fix MDTF install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Run complete (default) installation without prompts
 | CMECTEST | Example CMEC module | https://github.com/cmecmetrics/example_cmec_module |
 | Drought_Metrics | Drought Metrics | https://github.com/cmecmetrics/Drought_Metrics |
 | ILAMB | International Land Model Benchmarking | https://github.com/rubisco-sfa/ILAMB |
-| MDTF_Diagnostics (see issue #4) | Model Diagnostics Task Force | https://github.com/NOAA-GFDL/MDTF-diagnostics |
+| MDTF_Diagnostics | Model Diagnostics Task Force | https://github.com/NOAA-GFDL/MDTF-diagnostics |
 | PMP | PCMDI Metrics Package |  https://github.com/PCMDI/pcmdi_metrics |
 
 

--- a/cmec-driver-recipes/MDTF_Diagnostics.sh
+++ b/cmec-driver-recipes/MDTF_Diagnostics.sh
@@ -16,7 +16,7 @@ module_download "${user_prompt}" "${wget_path}"  ${archive_name}
 # Write contents.json
 echo
 echo "Creating contents.json"
-python generate_contents.py modules/MDTF_Diagnostics modules/MDTF_Diagnostics/diagnostics MDTF_Diagnostics "MDTF Diagnostics package version "${mdtf_version}
+python generate_contents.py $CMEC_MODULE_DIR $CMEC_MODULE_DIR/diagnostics MDTF_Diagnostics "MDTF Diagnostics package version "${mdtf_version}
 
 CONDA_ROOT=$(conda info --base)
 
@@ -36,15 +36,17 @@ echo "https://github.com/NOAA-GFDL/MDTF-diagnostics"
 echo "***********************END INFO***************************"
 echo
 sleep .5
-while true; do
-	read -p "Install MDTF conda environments (see INFO above)? [y/n] " yn
-	case $yn in
-		[Yy]* ) break;; #continue to next section for install
-		[Nn]* ) echo "Skipping conda environments for MDTF Diagnostics.";
-				exit;;
-		* ) echo "Please answer yes (y) or no (n).";;
-	esac
-done
+if [ $USE_PROMPTS == "1" ]; then
+	while true; do
+		read -p "Install MDTF conda environments (see INFO above)? [y/n] " yn
+		case $yn in
+			[Yy]* ) break;; #continue to next section for install
+			[Nn]* ) echo "Skipping conda environments for MDTF Diagnostics.";
+					exit;;
+			* ) echo "Please answer yes (y) or no (n).";;
+		esac
+	done
+fi
 
 # Call the MDTF script for conda environment install
 cd $CMEC_MODULE_DIR

--- a/cmec-driver-recipes/bash_helper_functions.sh
+++ b/cmec-driver-recipes/bash_helper_functions.sh
@@ -50,19 +50,6 @@ git_clone () {
         git clone -q git@$1:$2.git $3
         ret=$?
     fi
-    #while true; do
-	#    read -p "Use (a) HTTPS or (b) SSH?  [A/b] " AB
-	#    case $AB in
-	#	    [Bb]* ) echo "Cloning git repository"
-    #                git clone -q git@github.com:$1.git $2
-    #                ret=$?
-    #                break;;
-	#	    * ) echo "Cloning git repository"
-    #            git clone -q https://github.com/$1.git $2
-    #            ret=$?
-    #            break;;
-	#    esac
-    #done
 
     # Git clone will fail if we didn't overwrite the module directory
     # before running the recipe. So check for this error and update repo if needed.
@@ -252,8 +239,12 @@ module_download () {
         exit
     fi
     tmp_archive_name=$(echo $2 | cut -d '/' -f 9)
+    rm -rf $CMEC_MODULE_DIR
 	tar -xf $CMEC_MODULES_HOME/$tmp_archive_name -C $CMEC_MODULES_HOME
-    mv $3 
+    # If extracted archive name is not the same as the module name:
+    if [ ! -d $CMEC_MODULE_DIR ]; then
+        mv $CMEC_MODULES_HOME/$3 $CMEC_MODULE_DIR
+    fi
     rm $CMEC_MODULES_HOME/$tmp_archive_name
 
 }

--- a/setup_module.py
+++ b/setup_module.py
@@ -16,6 +16,7 @@ Arguments:
 import argparse
 import json
 import os
+import shutil
 import sys
 import subprocess
 
@@ -164,14 +165,8 @@ if __name__ == "__main__":
                 "Overwrite directory {0}?".format(module_dir))
         
         if overwrite:
-            try:
-                subprocess.run(["rm","-rf",module_dir],
-                               shell=False,
-                               check=True)
-            except subprocess.CalledProcessError:
-                print("Could not overwrite module directory.")
-                print("Exiting.")
-                sys.exit()
+            if os.path.exists(module_dir):
+                shutil.rmtree(module_dir)
         else:
             print("Skip overwrite. This could result in "+
                   "unexpected behavior.\n")
@@ -238,12 +233,8 @@ if __name__ == "__main__":
                   "    cmec-driver register " + module_dir)
 
         # Remove temporary directory
-        try:
-            subprocess.run(["rm","-rf",tmp_dir],
-                            shell=False,
-                            check=True)
-        except subprocess.CalledProcessError:
-            print("\nCould not remove directory "+ tmp_dir)
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)
     else:
         print("\nSkipping run recipe for module",module)
         print("Exiting")


### PR DESCRIPTION
Folders downloaded with the module_download function will be moved into the $CMEC_MODULE_DIRECTORY. Use shutil instead of a subprocess call to remove directories in setup_module.py.

Closes #4 