### PR TITLE
Update version for MDTF Diagnostics download

### DIFF
--- a/cmec-driver-recipes/MDTF_Diagnostics.sh
+++ b/cmec-driver-recipes/MDTF_Diagnostics.sh
@@ -2,7 +2,7 @@
 
 source cmec-driver-recipes/bash_helper_functions.sh
 
-mdtf_version=3.0.beta.5
+mdtf_version=3.0
 
 # Set variables for download, using version variables
 user_prompt="Download MDTF Diagnostics version "${mdtf_version}"? "

--- a/cmec-driver-recipes/bash_helper_functions.sh
+++ b/cmec-driver-recipes/bash_helper_functions.sh
@@ -218,7 +218,7 @@ module_download () {
     #--------------------------------------------
     if [ $USE_PROMPTS == "1" ]; then
         while true; do
-	        read -p "$1" "[Y/n] " yn
+	        read -p "$1"" [Y/n] " yn
 	        case $yn in
 		        [Nn]* ) echo "Exiting without installation"
                         echo "CMEC driver cannot register module without download."


### PR DESCRIPTION
Update the MDTF Diagnostics version to 3.0 and fix a prompt issue in the module_download function.